### PR TITLE
Add tests for ClickUp integration

### DIFF
--- a/src/test_clickup.py
+++ b/src/test_clickup.py
@@ -6,8 +6,11 @@ Run this script to test your ClickUp setup before running the Discord bot.
 
 import os
 import sys
+import pytest
 from dotenv import load_dotenv
 from bot import ClickUpClient
+
+pytest.skip("manual integration script", allow_module_level=True)
 
 def test_clickup_connection():
     """Test the ClickUp API connection and create a test task"""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))

--- a/tests/test_clickup_client.py
+++ b/tests/test_clickup_client.py
@@ -1,0 +1,62 @@
+import builtins
+from unittest.mock import Mock, patch
+
+from bot import ClickUpClient
+
+
+def test_get_folder_lists_success():
+    client = ClickUpClient("token", "list", folder_id="folder")
+    expected = [{"id": "1"}, {"id": "2"}]
+    with patch("bot.requests.get") as mock_get:
+        mock_resp = Mock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"lists": expected}
+        mock_get.return_value = mock_resp
+
+        lists = client.get_folder_lists()
+        assert lists == expected
+        mock_get.assert_called_once_with(
+            "https://api.clickup.com/api/v2/folder/folder/list",
+            headers=client.headers,
+        )
+
+
+def test_get_folder_lists_no_folder():
+    client = ClickUpClient("token", "list")
+    assert client.get_folder_lists() == []
+
+
+def test_get_newest_list_from_folder():
+    client = ClickUpClient("token", "list", folder_id="folder")
+    lists = [{"id": "1"}, {"id": "2"}]
+    with patch.object(client, "get_folder_lists", return_value=lists):
+        newest = client.get_newest_list_from_folder()
+        assert newest == lists[-1]
+
+
+def test_create_task_success():
+    client = ClickUpClient("token", "123")
+    with patch("bot.requests.post") as mock_post:
+        mock_resp = Mock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"id": "task"}
+        mock_post.return_value = mock_resp
+
+        result = client.create_task("Title", "Desc")
+        assert result == {"id": "task"}
+        mock_post.assert_called_once()
+        assert mock_post.call_args[0][0] == "https://api.clickup.com/api/v2/list/123/task"
+
+
+def test_update_task_status():
+    client = ClickUpClient("token", "list")
+    with patch("bot.requests.put") as mock_put:
+        mock_resp = Mock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"status": "complete"}
+        mock_put.return_value = mock_resp
+
+        result = client.update_task_status("id1", "complete")
+        assert result == {"status": "complete"}
+        mock_put.assert_called_once()
+        assert mock_put.call_args[0][0] == "https://api.clickup.com/api/v2/task/id1"

--- a/tests/test_handle_task_creation.py
+++ b/tests/test_handle_task_creation.py
@@ -1,0 +1,60 @@
+import types
+from datetime import datetime
+from unittest.mock import AsyncMock, Mock
+import asyncio
+import types
+
+import bot
+
+
+class DummyTyping:
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummyChannel:
+    def __init__(self):
+        self._history = []
+        self.name = "general"
+    def history(self, limit=20):
+        async def generator():
+            for msg in self._history:
+                yield msg
+        return generator()
+    def typing(self):
+        return DummyTyping()
+
+
+def test_handle_task_creation_creates_task(monkeypatch):
+    bot.bot._connection.user = types.SimpleNamespace(id=42)
+
+    channel = DummyChannel()
+    message = types.SimpleNamespace(
+        content="<@42> implement feature",
+        author=types.SimpleNamespace(display_name="User", name="user", discriminator="0001"),
+        channel=channel,
+        guild=types.SimpleNamespace(name="Guild"),
+        created_at=datetime.utcnow(),
+        jump_url="http://discord/message",
+    )
+
+    async def reply(embed=None):
+        message.replied = embed
+    message.reply = reply
+
+    monkeypatch.setattr(bot, "is_task_creation_command", AsyncMock(return_value=False))
+    monkeypatch.setattr(bot, "get_channel_context", AsyncMock(return_value=[]))
+    monkeypatch.setattr(bot, "filter_relevant_context", AsyncMock(return_value=[]))
+    monkeypatch.setattr(bot, "generate_smart_title", AsyncMock(return_value="Test Title"))
+    monkeypatch.setattr(bot, "determine_target_list", lambda content: (None, "Backlog"))
+
+    create_mock = Mock(return_value={"id": "1"})
+    monkeypatch.setattr(bot.clickup_client, "create_task", create_mock)
+
+    asyncio.run(bot.handle_task_creation(message))
+
+    create_mock.assert_called_once()
+    assert hasattr(message, "replied")
+    assert message.replied.title.startswith("✅")


### PR DESCRIPTION
## Summary
- add pytest helper to make `src` importable
- provide unit tests for `ClickUpClient`
- create integration-style test for `handle_task_creation`
- skip old manual `test_clickup.py` when running pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ac916d6cc8331aa6c9891344fe821